### PR TITLE
Added assertion that data set contains enough instances.

### DIFF
--- a/kmeans_dd.m
+++ b/kmeans_dd.m
@@ -42,7 +42,8 @@ elseif mapping_task(argin,'training')			% Train a mapping.
    [a,fracrej,K,errtol] = deal(argin{:});
 	a = +target_class(a);     % make sure a is an OC dataset
 	k = size(a,2);
-
+	assert(size(a, 1) >= K, 'The number of instances in the data set must be greater or equals to the K parameter.\nDataset rows: %d\nK parameter: %d', size(a, 1), K);
+	
 	% train it:
 	[labs,w] = mykmeans(a,K,errtol);
 


### PR DESCRIPTION
Without the added assertion, when a data set contains less instances than the K parameter, the algorithm try to access a invalid index. That error message doesn't help in the debugging process. So with this assertion developers can find architectural errors more easily.